### PR TITLE
Added support for LIST as command to perform "ls -l" on the download dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ You need to configure these values:
 |--------------------------|:-----------------------:|--------------------------------------------------------------|---------------------|
 | `TELEGRAM_DAEMON_API_ID`   | `--api-id`              | api_id from https://core.telegram.org/api/obtaining_api_id   |                     |
 | `TELEGRAM_DAEMON_API_HASH` | `--api-hash`            | api_hash from https://core.telegram.org/api/obtaining_api_id |                     |
-| `TELEGRAM_DAEMON_CHANNEL`  | `--dest`                | Destenation path for downloading files                       | `/telegram-downloads` |
-| `TELEGRAM_DAEMON_DEST`     | `--channel`             | Channel id to download from it                               |                     |
+| `TELEGRAM_DAEMON_DEST`     | `--dest`                | Destenation path for downloading files                       | `/telegram-downloads` |
+| `TELEGRAM_DAEMON_CHANNEL`  | `--channel`             | Channel id to download from it                               |                     |
 
 You can define the as Environment Variables, or put them as a commend line arguments, for example:
 

--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -4,6 +4,7 @@
 # You need to install telethon (and cryptg to speed up downloads)
 
 from os import getenv
+import subprocess
 
 from sessionManager import getSession, saveSession
 
@@ -100,6 +101,14 @@ with TelegramClient(getSession(), api_id, api_hash,
             return
 
         print(event)
+
+        if not event.media and event.message:
+            command = event.message.message
+            command = command.lower()
+            if command == "list":
+                output = subprocess.run(["ls", "-l", downloadFolder], capture_output=True).stdout
+                output = output.decode('utf-8')
+                await log_reply(event, output)
 
         if event.media:
             filename=getFilename(event)


### PR DESCRIPTION
Also fixed a typo in the documentation where variable names were swapped.

Basic functionality is working.
Maybe we should add a warning in the documentation that the download-directory should be exclusive to this daemon, from the privacy perspective.