### PR TITLE
Prefer DocumentAttributeFilename to DocumentAttributeVideo whenever available

### DIFF
--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -97,9 +97,11 @@ async def log_reply(event : events.ChatAction.Event, reply):
     await event.edit(reply)
  
 def getFilename(event: events.NewMessage.Event):
+    mediaFileName = "unknown"
     for attribute in event.media.document.attributes:
         if isinstance(attribute, DocumentAttributeFilename): return attribute.file_name
-        if isinstance(attribute, DocumentAttributeVideo): return event.original_update.message.message
+        if isinstance(attribute, DocumentAttributeVideo): mediaFileName = event.original_update.message.message
+    return mediaFileName
 
 
 in_progress={}


### PR DESCRIPTION
A message might contain both DocumentAttributeFilename and
DocumentAttributeVideo type of attributes. While iterating on
event.media.document.attributes, we might get DocumentAttributeVideo
first and the function returns the message text even though
attribute of DocumentAttributeFilename type is also available.