### PR TITLE
use shutil.move to support Docker Volumes

### DIFF
--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -3,7 +3,8 @@
 # Author: Alfonso E.M. <alfonso@el-magnifico.org>
 # You need to install telethon (and cryptg to speed up downloads)
 
-from os import getenv, rename
+from os import getenv
+from shutil import move
 import subprocess
 import math
 
@@ -191,7 +192,7 @@ with TelegramClient(getSession(), api_id, api_hash,
 
                 await client.download_media(event.message, "{0}/{1}.{2}".format(tempFolder,filename,TELEGRAM_DAEMON_TEMP_SUFFIX), progress_callback = download_callback)
                 set_progress(filename, message, 100, 100)
-                rename("{0}/{1}.{2}".format(tempFolder,filename,TELEGRAM_DAEMON_TEMP_SUFFIX), "{0}/{1}".format(downloadFolder,filename))
+                move("{0}/{1}.{2}".format(tempFolder,filename,TELEGRAM_DAEMON_TEMP_SUFFIX), "{0}/{1}".format(downloadFolder,filename))
                 await log_reply(message, "{0} ready".format(filename))
 
                 queue.task_done()


### PR DESCRIPTION
close #42 

Reference: https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link