### PR TITLE
If the download fails for some reason, inform the user about the reason 

### DIFF
--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -112,7 +112,7 @@ async def set_progress(filename, message, received, total):
         try: in_progress.pop(filename)
         except: pass
         return
-    percentage = math.trunc(received / total * 10000) / 100;
+    percentage = math.trunc(received / total * 10000) / 100
 
     in_progress[filename] = f"{percentage} % ({received} / {total})"
 

--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -222,6 +222,8 @@ with TelegramClient(getSession(), api_id, api_hash,
 
                 queue.task_done()
             except Exception as e:
+                try: await log_reply(message, "Error: {}".format(str(e))) # If it failed, inform the user about it.
+                except: pass
                 print('Queue worker error: ', e)
  
     async def start():


### PR DESCRIPTION
I often ended up in a situation where I forwarded a large file to the daemon. Since the file size limit is 1.5 GB, it failed.
However, I had to check the syslog to understand why it failed.
Also, I was not aware that it has already failed. I had used status command after some time to see the status and it showed no active download.

This small patch will inform the user about the failure.