### PR TITLE
Optimize docker image and Move from Python 3.6 to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM python:3.6
-
-WORKDIR /app
-
-COPY *.py ./
+FROM python:3.9-bullseye AS compile-image
 
 RUN echo $TARGETPLATFORM
-
 RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
     which lsb_release \
     lsb_release -a \
     mv /usr/bin/lsb_release /usr/bin/lsb_release.bak \
-    pip install telethon; \
+    pip install --no-cache-dir --user telethon; \
   else \
-    pip install telethon cryptg; \
+    pip install --no-cache-dir --user telethon cryptg; \
   fi
 
-CMD [ "python", "./telegram-download-daemon.py" ]
+FROM python:3.9-slim-bullseye AS run-image
+
+COPY --from=compile-image /root/.local /root/.local
+
+WORKDIR /app
+COPY *.py ./
+
+CMD [ "python3", "./telegram-download-daemon.py" ]


### PR DESCRIPTION
The python version is updated from 3.6 to 3.9 because version 3.6 is no longer officially maintained on dockerhub.

The previous image was built on the full python image which caused the final size to be bloated, this commit builds the image in layers, first in the full python image so it can build the pip packages and then copies what was installed with pip to a slim version of the python image which considerably reduces the size of the final image.