### PR TITLE
Fix compatibility issues with ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3 AS compile-image
 
 RUN pip install --no-cache-dir --user telethon cryptg==0.2
 
-FROM python:3 AS run-image
+FROM python:3-slime AS run-image
 
 COPY --from=compile-image /root/.local /root/.local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3 AS compile-image
 
 RUN pip install --no-cache-dir --user telethon cryptg==0.2
 
-FROM python:3-slime AS run-image
+FROM python:3-slim AS run-image
 
 COPY --from=compile-image /root/.local /root/.local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,8 @@
-FROM python:3.9-bullseye AS compile-image
+FROM python:3 AS compile-image
 
-RUN echo $TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
-    which lsb_release \
-    lsb_release -a \
-    mv /usr/bin/lsb_release /usr/bin/lsb_release.bak \
-    pip install --no-cache-dir --user telethon; \
-  else \
-    pip install --no-cache-dir --user telethon cryptg; \
-  fi
+RUN pip install --no-cache-dir --user telethon cryptg==0.2
 
-FROM python:3.9-slim-bullseye AS run-image
+FROM python:3 AS run-image
 
 COPY --from=compile-image /root/.local /root/.local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.5'
 
 services:
   telegram-download-daemon:
-    build: .
-    image: telegram-download-daemon:latest
+    #build: .
+    image: alfem/telegram-download-daemon:latest
     environment:
       TELEGRAM_DAEMON_API_ID: "YOUR API ID HERE"
       TELEGRAM_DAEMON_API_HASH: "YOUR API HASH HERE"


### PR DESCRIPTION
Tested on Raspberry Pi 4 Model B (aarch64/armv8).

BuildKit and TARGETPLATFORM gives a lot of issues since docker-compose v3, and it was not necessary to separate both platforms.

With this change there are no more issues with any platform, and it is also more efficient since armv7 also uses cryptg.