### PR TITLE
Clarify purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # telegram-download-daemon
 
-A Telegram Daemon (not a bot) for file downloading automation 
+A Telegram Daemon (not a bot) for file downloading automation [for channels of which you have admin priviliges](https://github.com/alfem/telegram-download-daemon/issues/48).
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/E1E03K0RP)
 
 If you have got an Internet connected computer or NAS and you want to automate file downloading from Telegram channels, this
-daemon is for you. 
+daemon is for you.
 
 Telegram bots are limited to 20Mb file size downloads. So I wrote this agent
 or daemon to allow bigger downloads (limited to 2GB by Telegram APIs).


### PR DESCRIPTION
* Not everyone is aware of the limitations of Telegram API and as such users may be beguiled into thinking that one could download files from any public channels using this daemon.
* The reality of the matter is that Telegram API only allows you to download from a channel in which you have admin rights.
* The desired workflow instead would be that for public channels; you would manually forward files to a channel for which you have admin rights over in order for this daemon to be of any use.