### PR TITLE
resolve alfem/telegram-download-daemon#72

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       TELEGRAM_DAEMON_CHANNEL: "YOUR CHANNEL ID HERE"
       TELEGRAM_DAEMON_DEST: "/downloads"
       TELEGRAM_DAEMON_SESSION_PATH: "/session"
+      #TELEGRAM_DAEMON_SIMULTANEUS: 2
     volumes:
        - downloads:/downloads
        - sessions:/session

--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -41,6 +41,13 @@ TELEGRAM_DAEMON_DUPLICATES=getenv("TELEGRAM_DAEMON_DUPLICATES", "rename")
 
 TELEGRAM_DAEMON_TEMP_SUFFIX="tdd"
 
+TELEGRAM_DAEMON_SIMULTANEUS=getenv("TELEGRAM_DAEMON_SIMULTANEUS", "multiprocessing.cpu_count()")
+
+if TELEGRAM_DAEMON_SIMULTANEUS == "multiprocessing.cpu_count()":
+    simultaneous_type = str
+else:
+    simultaneous_type = int
+
 parser = argparse.ArgumentParser(
     description="Script to download files from a Telegram Channel.")
 parser.add_argument(
@@ -87,6 +94,13 @@ parser.add_argument(
     help=
     '"ignore"=do not download duplicated files, "rename"=add a random suffix, "overwrite"=redownload and overwrite.'
 )
+parser.add_argument(
+    "--simultaneus",
+    type=simultaneous_type,
+    default=TELEGRAM_DAEMON_SIMULTANEUS,
+    help=
+    'number of simultaneous downloads'
+)
 args = parser.parse_args()
 
 api_id = args.api_id
@@ -95,7 +109,7 @@ channel_id = args.channel
 downloadFolder = args.dest
 tempFolder = args.temp
 duplicates=args.duplicates
-worker_count = multiprocessing.cpu_count()
+worker_count = args.simultaneus
 updateFrequency = 10
 lastUpdate = 0
 #multiprocessing.Value('f', 0)


### PR DESCRIPTION
This commit adds a new environment variable TELEGRAM_DAEMON_SIMULTANEUS that can be used to specify the maximum number of concurrent downloads that can be processed

Previously, this value was hardcoded in the application code, but now it can be customized from the docker-compose.yml. This makes it easier for users to adjust the value to their specific needs without having to modify the codebase.